### PR TITLE
feat(graphql): preflight request plugin, to match REST implementation

### DIFF
--- a/Plugin/GraphQl/PreflightRequestHandler.php
+++ b/Plugin/GraphQl/PreflightRequestHandler.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+namespace Graycore\Cors\Plugin\GraphQl;
+
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Webapi\Rest\Request as RestRequest;
+use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\GraphQl\Controller\GraphQl as GraphQlController;
+use Magento\Framework\App\Response\HeaderManager;
+
+/**
+ * PreflightRequestHandler is responsible for returning a
+ * 200 response to an options request on the graphql endpoint.
+ * @author    Matthew O'Loughlin <matthew@aligent.com.au>
+ * @copyright Graycore, LLC (https://www.graycore.io/)
+ * @license   MIT https://github.com/graycoreio/magento2-cors/license
+ * @link      https://github.com/graycoreio/magento2-cors
+ */
+class PreflightRequestHandler
+{
+
+    /** @var HttpResponse */
+    private $_response;
+
+    /** @var HeaderManager */
+    private $headerManager;
+
+    public function __construct(HttpResponse $response, HeaderManager $headerManager)
+    {
+        $this->_response = $response;
+        $this->_headerManager = $headerManager;
+    }
+
+    /**
+     * @param GraphQlController $subject
+     * @param callable $next
+     * @param RequestInterface $request
+     * @return \Magento\Framework\App\Response\HttpInterface
+     */
+    public function aroundDispatch(GraphQlController $subject, callable $next, RequestInterface $request)
+    {
+        if ($request instanceof Http && $request->isOptions()) {
+            $this->_headerManager->beforeSendResponse($this->_response);
+            $this->_response->setNoCacheHeaders();
+            return $this->_response;
+        }
+
+        return $next($request);
+    }
+}

--- a/Plugin/Rest/PreflightRequestHandler.php
+++ b/Plugin/Rest/PreflightRequestHandler.php
@@ -3,17 +3,18 @@
  * Copyright © Graycore, LLC. All rights reserved.
  * See LICENSE.md for details.
  */
-namespace Graycore\Cors\Response;
+namespace Graycore\Cors\Plugin\Rest;
 
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\RequestInterface;
-use Magento\Webapi\Controller\Rest as RestController;
 use Magento\Framework\Webapi\Rest\Request as RestRequest;
 use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\Webapi\Controller\Rest as RestController;
+use Graycore\Cors\Response\HeaderManager;
 
 /**
  * PreflightRequestHandler is responsible for returning a
- * 200 response to an options request.
+ * 200 response to an options request on a REST endpoint.
  * @author    Graycore <damien@graycore.io>
  * @copyright Graycore, LLC (https://www.graycore.io/)
  * @license   MIT https://github.com/graycoreio/magento2-cors/license
@@ -35,9 +36,10 @@ class PreflightRequestHandler
     }
 
     /**
-     * @param RestRequest $subject
-     *
-     * @return string
+     * @param RestController $subject
+     * @param callable $next
+     * @param RequestInterface $request
+     * @return \Magento\Framework\App\Response\HttpInterface
      */
     public function aroundDispatch(RestController $subject, callable $next, RequestInterface $request)
     {
@@ -45,7 +47,6 @@ class PreflightRequestHandler
             return $this->_headerManager->applyHeaders($this->_response);
         }
 
-        /** @var HttpResponse $response */
         return $next($request);
     }
 }

--- a/Response/HeaderManager.php
+++ b/Response/HeaderManager.php
@@ -40,7 +40,7 @@ class HeaderManager
 
      /**
       * @param \Magento\Framework\App\Response\HttpInterface $response
-      * @return void
+      * @return \Magento\Framework\App\Response\HttpInterface
       */
     public function applyHeaders(\Magento\Framework\App\Response\HttpInterface $response)
     {

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Graycore\Cors\Configuration\CorsConfigurationInterface" type="Graycore\Cors\Configuration\GraphQl\CorsConfiguration" />
-    <preference 
-        for="Graycore\Cors\Validator\CorsValidatorInterface" 
-        type="Graycore\Cors\Validator\CorsValidator"/>
+    <preference for="Graycore\Cors\Validator\CorsValidatorInterface" type="Graycore\Cors\Validator\CorsValidator"/>
     <type name="Magento\Framework\App\Response\HeaderManager">
         <arguments>
             <argument name="headerProviderList" xsi:type="array">
@@ -14,5 +12,8 @@
                 <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
             </argument>
         </arguments>
+    </type>
+    <type name="Magento\GraphQl\Controller\GraphQl">
+        <plugin name="graycoreCorsPreflightHandlerGraphQl" type="Graycore\Cors\Plugin\GraphQl\PreflightRequestHandler" />
     </type>
 </config>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -14,7 +14,7 @@
         </arguments>
     </type>
     <type name="Magento\Webapi\Controller\Rest">
-        <plugin name="graycoreCorsPreflightHandlerRest" type="Graycore\Cors\Response\PreflightRequestHandler" />
+        <plugin name="graycoreCorsPreflightHandlerRest" type="Graycore\Cors\Plugin\Rest\PreflightRequestHandler" />
     </type>
     <type name="Magento\Framework\Webapi\Rest\Response">
         <plugin name="genericWebApiHeaderPlugin" type="Graycore\Cors\Response\HeaderManager"/>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -14,7 +14,8 @@
         </arguments>
     </type>
     <type name="Magento\Webapi\Controller\Rest">
-        <plugin name="graycoreCorsPreflightHandlerRest" type="Graycore\Cors\Plugin\Rest\PreflightRequestHandler" />
+        <!-- Sort Order is a temporary workaround to address OPTIONS requests causing a fatal error in module-staging plugin -->
+        <plugin name="graycoreCorsPreflightHandlerRest" sortOrder="-1" type="Graycore\Cors\Plugin\Rest\PreflightRequestHandler" />
     </type>
     <type name="Magento\Framework\Webapi\Rest\Response">
         <plugin name="genericWebApiHeaderPlugin" type="Graycore\Cors\Response\HeaderManager"/>


### PR DESCRIPTION
Resolves an issue where the graphql query is serviced as part of each OPTIONS request; this means that an empty body is processed, causing an error to be reported back on the response body (and logged to exception.log).

This adds a preflight request short-circuit plugin to roughly match the REST implementation. The main distinction is that Magento_GraphQlCache wires up \Magento\PageCache\Model\App\FrontController\BuiltinPlugin::aroundDispatch, which expects a Cache-Control header to be set. And this won't be the case without letting the dispatch run.

Currently just resorting to using setNoCacheHeaders for the preflight request, though I don't know the full impact of that yet. There is already a Max-Age header, which this module does populate, for providing OPTIONS response TTL.